### PR TITLE
Printing the even numbers in a given range

### DIFF
--- a/Work_8.py
+++ b/Work_8.py
@@ -1,0 +1,34 @@
+# # Write a Python program to print all even numbers from a given list of numbers 
+# in the same order and stop printing any after 237 in the sequence.
+# Sample numbers list :
+
+numbers =  [386, 462, 47, 418, 907, 344, 236, 375, 823, 566, 597, 978, 328, 615, 953, 345, 
+    399, 162, 758, 219, 918, 237, 412, 566, 826, 248, 866, 950, 626, 949, 687, 217, 
+    815, 67, 104, 58, 512, 24, 892, 894, 767, 553, 81, 379, 843, 831, 445, 742, 717, 
+    958,743,527] 
+
+
+# for n in numbers:
+#   if n==237:
+#     break
+#   if n %2==0:
+#      print(n)
+
+##User giving the starting and ending points
+
+# s_point=int(input("Enter starting point: "))
+# e_point=int(input("Enter ending point: "))
+# for n in range(s_point, e_point):
+#     if n%2 == 0:
+#         print(n)
+
+##Using functions
+
+
+def even_num(s_point, e_point):
+    for n in range(s_point, e_point + 1):
+        if n % 2 == 0:
+            print(n)
+s_point = int(input("Enter starting point: "))
+e_point = int(input("Enter ending point: "))
+even_num(s_point, e_point)


### PR DESCRIPTION
Write a Python program to print all even numbers from a given list of numbers
 in the same order and stop printing any after 237 in the sequence.
# Sample numbers list :

numbers =  [386, 462, 47, 418, 907, 344, 236, 375, 823, 566, 597, 978, 328, 615, 953, 345, 
    399, 162, 758, 219, 918, 237, 412, 566, 826, 248, 866, 950, 626, 949, 687, 217, 
    815, 67, 104, 58, 512, 24, 892, 894, 767, 553, 81, 379, 843, 831, 445, 742, 717, 
    958,743,527] 